### PR TITLE
Debug stats

### DIFF
--- a/run_stats.py
+++ b/run_stats.py
@@ -17,6 +17,7 @@ sampling_params = SamplingParams(
     top_p=0.95,
     max_tokens=500,
     stop="is",
+    n=2,
     output_kind=RequestOutputKind.CUMULATIVE,
     # stop_token_ids=[5],
 )

--- a/run_stats.py
+++ b/run_stats.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# hf download Qwen/Qwen3-0.6B --local-dir /data/local/models/qwen3_06b
+# rm /data/local/models/qwen3_06b/tokenizer*
+
+from vllm import LLM, SamplingParams, TokensPrompt
+from vllm.sampling_params import RequestOutputKind
+
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    # "The capital of France is",
+    # "The future of AI is",
+]
+sampling_params = SamplingParams(
+    temperature=0.8,
+    top_p=0.95,
+    max_tokens=500,
+    stop="is",
+    output_kind=RequestOutputKind.CUMULATIVE,
+    # stop_token_ids=[5],
+)
+tokens_prompt = TokensPrompt(prompt_token_ids=[2, 3, 4], )
+
+if __name__ == "__main__":
+    llm = LLM(
+        model="Qwen/Qwen3-0.6B",
+        enforce_eager=True,
+        # skip_tokenizer_init=True,
+        gpu_memory_utilization=0.8,
+        disable_log_stats=False,
+    )
+    outputs = llm.generate(prompts=prompts, sampling_params=sampling_params)
+    for output in outputs:
+        prompt = output.prompt_token_ids
+        generated_token_ids = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated tokens: {generated_token_ids!r}")

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -46,8 +46,7 @@ from vllm.outputs import (ClassificationRequestOutput, EmbeddingRequestOutput,
                           ScoringRequestOutput)
 from vllm.plugins.io_processors import get_io_processor
 from vllm.pooling_params import PoolingParams
-from vllm.sampling_params import (BeamSearchParams, RequestOutputKind,
-                                  SamplingParams)
+from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tasks import PoolingTask
 from vllm.transformers_utils.tokenizer import (AnyTokenizer, MistralTokenizer,
                                                get_cached_tokenizer,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -90,7 +90,7 @@ class LLM:
             or videos from directories specified by the server file system.
             This is a security risk. Should only be enabled in trusted
             environments.
-        allowed_media_domains: If set, only media URLs that belong to this 
+        allowed_media_domains: If set, only media URLs that belong to this
             domain can be used for multi-modal inputs.
         tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
@@ -1504,10 +1504,10 @@ class LLM:
             raise ValueError("The lengths of prompts and lora_request "
                              "must be the same.")
 
-        for sp in params if isinstance(params, Sequence) else (params, ):
-            if isinstance(sp, SamplingParams):
-                # We only care about the final output
-                sp.output_kind = RequestOutputKind.FINAL_ONLY
+        # for sp in params if isinstance(params, Sequence) else (params, ):
+        #     if isinstance(sp, SamplingParams):
+        #         # We only care about the final output
+        #         sp.output_kind = RequestOutputKind.FINAL_ONLY
 
         # Add requests to the engine.
         it = prompts

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -274,6 +274,7 @@ class LLMEngine:
 
         # 1) Get EngineCoreOutput from the EngineCore.
         outputs = self.engine_core.get_output()
+        logger.info(f"{len(outputs.outputs)=}")
 
         # 2) Process EngineCoreOutputs.
         iteration_stats = IterationStats() if self.log_stats else None
@@ -294,6 +295,9 @@ class LLMEngine:
             )
             self.do_log_stats_with_interval()
 
+        logger.info(
+            f"EngineCore: {outputs.scheduler_stats=}, {iteration_stats=}, {processed_outputs.request_outputs=}"
+        )
         return processed_outputs.request_outputs
 
     def get_vllm_config(self):

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -193,6 +193,7 @@ class RequestState:
         kv_transfer_params: Optional[dict[str, Any]] = None,
     ) -> Optional[Union[RequestOutput, PoolingRequestOutput]]:
 
+        logger.info(f"{self.request_id=}, {self.output_kind=}, {finish_reason=}, {stop_reason=}")
         finished = finish_reason is not None
         final_only = self.output_kind == RequestOutputKind.FINAL_ONLY
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Union, cast
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.outputs import (CompletionOutput, PoolingOutput,
                           PoolingRequestOutput, RequestOutput)
 from vllm.sampling_params import RequestOutputKind
@@ -21,6 +22,8 @@ from vllm.v1.engine.logprobs import LogprobsProcessor
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import (IterationStats, LoRARequestStates,
                                    RequestStateStats)
+
+logger = init_logger(__name__)
 
 
 class RequestOutputCollector:
@@ -446,6 +449,9 @@ class OutputProcessor:
             if request_output := req_state.make_request_output(
                     new_token_ids, pooling_output, finish_reason, stop_reason,
                     kv_transfer_params):
+                assert isinstance(request_output, RequestOutput)
+                logger.info(
+                    f"Request {req_id} metrics: {request_output.metrics}")
                 if req_state.queue is not None:
                     # AsyncLLM: put into queue for handling by generate().
                     req_state.queue.put(request_output)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -193,7 +193,9 @@ class RequestState:
         kv_transfer_params: Optional[dict[str, Any]] = None,
     ) -> Optional[Union[RequestOutput, PoolingRequestOutput]]:
 
-        logger.info(f"{self.request_id=}, {self.output_kind=}, {finish_reason=}, {stop_reason=}")
+        logger.info(
+            f"{self.request_id=}, {self.output_kind=}, {finish_reason=}, {stop_reason=}"
+        )
         finished = finish_reason is not None
         final_only = self.output_kind == RequestOutputKind.FINAL_ONLY
 


### PR DESCRIPTION
```
INFO 10-04 14:05:38 [llm.py:310] Supported_tasks: ['generate']
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=4.941321803586529e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=2, queries=10, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=2, queries=14, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=9.882643607161956e-05, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=4
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=4, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:39 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:39 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22582240>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f23a01d90>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [output_processor.py:453] Request 0_1 metrics: RequestStateStats(num_generation_tokens=33, arrival_time=1759611939.7106962, queued_ts=3392014.154878037, scheduled_ts=3392014.154887912, first_token_ts=3392014.168248312, last_token_ts=3392014.490322987, first_token_latency=0.05086398124694824)
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[RequestOutput(request_id=1, prompt='The president of the United States is', prompt_token_ids=[785, 4767, 315, 279, 3639, 4180, 374], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' a person who has to appoint only 1 person for each person in the state of Texas, but he does not need to appoint people for other states. He ', token_ids=[264, 1697, 879, 702, 311, 9540, 1172, 220, 16, 1697, 369, 1817, 1697, 304, 279, 1584, 315, 8257, 11, 714, 566, 1558, 537, 1184, 311, 9540, 1251, 369, 1008, 5302, 13, 1260, 374], cumulative_logprob=None, logprobs=None, finish_reason=stop, stop_reason=is), CompletionOutput(index=1, text=' the only person who has the power to create and enforce laws. Which of the following statements ', token_ids=[279, 1172, 1697, 879, 702, 279, 2355, 311, 1855, 323, 28162, 6872, 13, 15920, 315, 279, 2701, 12239, 374], cumulative_logprob=None, logprobs=None, finish_reason=stop, stop_reason=is)], finished=True, metrics=RequestStateStats(num_generation_tokens=33, arrival_time=1759611939.7106962, queued_ts=3392014.154878037, scheduled_ts=3392014.154887912, first_token_ts=3392014.168248312, last_token_ts=3392014.490322987, first_token_latency=0.05086398124694824), lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=3
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=3, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2255f350>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=2
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=2, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f22581910>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f225819d0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00014823965410748485, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.000172946263125362, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00019765287214335014, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:40 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:40 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00022235948116122728, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002470660901791044, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.00027177269919698155, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f2e8d0200>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f25b66420>, processed_outputs.request_outputs=[]
INFO 10-04 14:05:41 [llm_engine.py:277] len(outputs.outputs)=1
INFO 10-04 14:05:41 [output_processor.py:453] Request 0_0 metrics: RequestStateStats(num_generation_tokens=187, arrival_time=1759611939.6918318, queued_ts=3392014.118035717, scheduled_ts=3392014.118145124, first_token_ts=3392014.154796472, last_token_ts=3392015.930020975, first_token_latency=0.056993961334228516)
INFO 10-04 14:05:41 [llm_engine.py:298] EngineCore: outputs.scheduler_stats=SchedulerStats(num_running_reqs=1, num_waiting_reqs=0, step_counter=0, current_wave=0, kv_cache_usage=0.0002964793082149697, prefix_cache_stats=PrefixCacheStats(reset=False, requests=0, queries=0, hits=0, preempted_requests=0, preempted_queries=0, preempted_hits=0), spec_decoding_stats=None, kv_connector_stats=None, num_corrupted_reqs=0), iteration_stats=<vllm.v1.metrics.stats.IterationStats object at 0x7f7f239721b0>, processed_outputs.request_outputs=[RequestOutput(request_id=0, prompt='Hello, my name is', prompt_token_ids=[9707, 11, 847, 829, 374], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=" Josh and I'm in the middle of a project to develop a hybrid mobile app. I'm looking for guidance on how to go about using modular frameworks. I want to use React and Vue. I need to decide on the framework to use. Can you help me choose the right framework and suggest some best practices for using them?\n\nAdditionally, I want to know what are the best practices for using a modular framework in the context of a web application? Also, what are the best practices for using a modular framework in the context of a mobile application? Also, what are the best practices for using a modular framework in the context of a hybrid app? Please explain each of these best practices. Also, what are the best practices for using a modular framework when integrating a third-party application with a third-party framework? Also, please explain each of these best practices in simple terms and explain each of these best practices in simple terms. Please l", token_ids=[18246, 323, 358, 2776, 304, 279, 6149, 315, 264, 2390, 311, 2225, 264, 24989, 6371, 906, 13, 358, 2776, 3330, 369, 18821, 389, 1246, 311, 728, 911, 1667, 43893, 48025, 13, 358, 1366, 311, 990, 3592, 323, 22256, 13, 358, 1184, 311, 10279, 389, 279, 12626, 311, 990, 13, 2980, 498, 1492, 752, 5157, 279, 1290, 12626, 323, 4190, 1045, 1850, 12378, 369, 1667, 1105, 1939, 49574, 11, 358, 1366, 311, 1414, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 304, 279, 2266, 315, 264, 3482, 3766, 30, 7281, 11, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 304, 279, 2266, 315, 264, 6371, 3766, 30, 7281, 11, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 304, 279, 2266, 315, 264, 24989, 906, 30, 5209, 10339, 1817, 315, 1493, 1850, 12378, 13, 7281, 11, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 979, 53852, 264, 4843, 24031, 3766, 448, 264, 4843, 24031, 12626, 30, 7281, 11, 4486, 10339, 1817, 315, 1493, 1850, 12378, 304, 4285, 3793, 323, 10339, 1817, 315, 1493, 1850, 12378, 304, 4285, 3793, 13, 5209, 1140], cumulative_logprob=None, logprobs=None, finish_reason=stop, stop_reason=is), CompletionOutput(index=1, text=" Tom. I'm from the UK and live in California. I'm a computer programmer and I love programming. I'm very enthusiastic about programming and I've never been shy. I'm currently working on a project that involves creating a game. Let me know if there's anything I can do to support you, Tom.\nOkay, I need to help Tom from the UK to the US. Let me think about how to approach th", token_ids=[8364, 13, 358, 2776, 504, 279, 6424, 323, 3887, 304, 7043, 13, 358, 2776, 264, 6366, 47788, 323, 358, 2948, 15473, 13, 358, 2776, 1602, 41602, 911, 15473, 323, 358, 3003, 2581, 1012, 32294, 13, 358, 2776, 5023, 3238, 389, 264, 2390, 429, 17601, 6825, 264, 1809, 13, 6771, 752, 1414, 421, 1052, 594, 4113, 358, 646, 653, 311, 1824, 498, 11, 8364, 624, 32313, 11, 358, 1184, 311, 1492, 8364, 504, 279, 6424, 311, 279, 2274, 13, 6771, 752, 1744, 911, 1246, 311, 5486, 419], cumulative_logprob=None, logprobs=None, finish_reason=stop, stop_reason=is)], finished=True, metrics=RequestStateStats(num_generation_tokens=187, arrival_time=1759611939.6918318, queued_ts=3392014.118035717, scheduled_ts=3392014.118145124, first_token_ts=3392014.154796472, last_token_ts=3392015.930020975, first_token_latency=0.056993961334228516), lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})]
Prompt: [9707, 11, 847, 829, 374], Generated tokens: [18246, 323, 358, 2776, 304, 279, 6149, 315, 264, 2390, 311, 2225, 264, 24989, 6371, 906, 13, 358, 2776, 3330, 369, 18821, 389, 1246, 311, 728, 911, 1667, 43893, 48025, 13, 358, 1366, 311, 990, 3592, 323, 22256, 13, 358, 1184, 311, 10279, 389, 279, 12626, 311, 990, 13, 2980, 498, 1492, 752, 5157, 279, 1290, 12626, 323, 4190, 1045, 1850, 12378, 369, 1667, 1105, 1939, 49574, 11, 358, 1366, 311, 1414, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 304, 279, 2266, 315, 264, 3482, 3766, 30, 7281, 11, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 304, 279, 2266, 315, 264, 6371, 3766, 30, 7281, 11, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 304, 279, 2266, 315, 264, 24989, 906, 30, 5209, 10339, 1817, 315, 1493, 1850, 12378, 13, 7281, 11, 1128, 525, 279, 1850, 12378, 369, 1667, 264, 43893, 12626, 979, 53852, 264, 4843, 24031, 3766, 448, 264, 4843, 24031, 12626, 30, 7281, 11, 4486, 10339, 1817, 315, 1493, 1850, 12378, 304, 4285, 3793, 323, 10339, 1817, 315, 1493, 1850, 12378, 304, 4285, 3793, 13, 5209, 1140]
Prompt: [785, 4767, 315, 279, 3639, 4180, 374], Generated tokens: [264, 1697, 879, 702, 311, 9540, 1172, 220, 16, 1697, 369, 1817, 1697, 304, 279, 1584, 315, 8257, 11, 714, 566, 1558, 537, 1184, 311, 9540, 1251, 369, 1008, 5302, 13, 1260, 374]
ERROR 10-04 14:05:41 [core_client.py:564] Engine core proc EngineCore_DP0 died unexpectedly, shutting down client.

```